### PR TITLE
chore: remove println from validate function

### DIFF
--- a/src/validation.rs
+++ b/src/validation.rs
@@ -70,9 +70,6 @@ pub fn validate(init_data: &str, token: &str, expires_in: Option<u64>) -> Result
 
     let (base_data, hash) = extract_hash(init_data)?;
 
-    println!("base_data: {}", base_data);
-    println!("hash: {}", hash);
-
     let expected_hash = sign(&base_data, token)?;
 
     if hash != expected_hash {


### PR DESCRIPTION
Those prints shouldn't be there, at best we could use the log crate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed debug print statements from the validation process to improve output clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->